### PR TITLE
Only indent non-empty lines

### DIFF
--- a/tasks/umd.js
+++ b/tasks/umd.js
@@ -41,6 +41,7 @@ module.exports = function(grunt) {
 
         if (options.indent) {
             code = code.split(/\r?\n/g).map(function(line) {
+                if (line === '') return line;
                 return options.indent + line;
             }).join(grunt.util.linefeed);
         }


### PR DESCRIPTION
The 'indent' option will add the indent string to lines that have no other content, this prevents that.
