### PR TITLE
Update umd.hbs to use current returnExports implementation.

### DIFF
--- a/templates/umd.hbs
+++ b/templates/umd.hbs
@@ -1,17 +1,22 @@
-(function(root, factory) {
-    if(typeof exports === 'object') {
-        module.exports = factory({{{cjsDependencies}}});
-    }
-    else if(typeof define === 'function' && define.amd) {
-        define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies}}}], factory);
-    }
-    else {
-        {{#if globalAlias}}root['{{{globalAlias}}}'] = {{else}}{{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}{{/if}}factory({{{globalDependencies}}});
-    }
-}(this, function({{dependencies}}) {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies}}}], function ({{dependencies}}) {
+      return (root.returnExportsGlobal = factory({{dependencies}}));
+    });
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like enviroments that support module.exports,
+    // like Node.
+    module.exports = factory({{{cjsDependencies}}});
+  } else {
+    {{#if globalAlias}}root['{{{globalAlias}}}'] = {{else}}{{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}{{/if}}factory({{{globalDependencies}}});
+  }
+}(this, function ({{dependencies}}) {
 
 {{{code}}}
 {{#if objectToExport}}
 {{indent}}return {{{objectToExport}}};
 {{/if}}
+
 }));


### PR DESCRIPTION
Looks like the current template is slightly out of date. I have manually been adding the following template to my project src and referencing it in the grunt config. I was starting to feel a little selfish. Now everyone can enjoy.
