### PR TITLE
support Grunt multitask options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,22 @@ Then configure the task:
 grunt.initConfig({
     umd: {
         all: {
-            src: 'path/to/input.js',
-            dest: 'path/to/output.js', // optional, if missing the src will be used
-            template: 'path/to/template.hbs', // optional; a template from templates subdir can be specified by name (e.g. 'umd');
-                // if missing the templates/umd.hbs file will be used
-            objectToExport: 'library', // optional, internal object that will be exported
-            amdModuleId: 'id', // optional, if missing the AMD module will be anonymous
-            globalAlias: 'alias', // optional, changes the name of the global variable
-            indent: '  ', // optional, indent source code
-            deps: { // optional
-                'default': ['foo', 'bar'],
-                amd: ['foobar', 'barbar'],
-                cjs: ['foo', 'barbar'],
-                global: ['foobar', 'bar']
+            options: {
+                src: 'path/to/input.js',
+                dest: 'path/to/output.js', // optional, if missing the src will be used
+                template: 'path/to/template.hbs', // optional, a template from templates subdir 
+                    // can be specified by name (e.g. 'umd'); if missing, the templates/umd.hbs 
+                    // file will be used
+                objectToExport: 'library', // optional, internal object that will be exported
+                amdModuleId: 'id', // optional, if missing the AMD module will be anonymous
+                globalAlias: 'alias', // optional, changes the name of the global variable
+                indent: '  ', // optional, indent source code
+                deps: { // optional
+                    'default': ['foo', 'bar'],
+                    amd: ['foobar', 'barbar'],
+                    cjs: ['foo', 'barbar'],
+                    global: ['foobar', 'bar']
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-umd",
   "description": "Surrounds code with the universal module definition.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "homepage": "https://github.com/bebraw/grunt-umd",
   "author": {
     "name": "Alex Lawrence",
@@ -19,6 +19,10 @@
     {
       "name": "Milan Adamovsky",
       "email": "milan.adamovsky@gmail.com"
+    },
+    {
+      "name": "Christopher Hiller",
+      "email": "chiller@badwing.com"
     }
   ],
   "repository": {

--- a/tasks/umd.js
+++ b/tasks/umd.js
@@ -45,7 +45,8 @@ module.exports = function(grunt) {
 
     grunt.registerMultiTask('umd', 'Surrounds code with the universal module definition.', function() {
         var file = grunt.file;
-        var options = this.data;
+        var data = extend({}, this.data);
+        var options = extend(data, this.options());
         var tplPath;
 
         try{


### PR DESCRIPTION
This change allows you to specify options to applied to multiple targets:

``` js
umd: {
  options: {
    template: 'path/to/template'
  },
  main: {
    src: 'path/to/src',
    dest: 'path/to/dest'
  },
  alternate: {
    src: 'path/to/src',
    dest: 'path/to/dest'
  }
}
```

This change is backwards-compatible with older versions of `grunt-umd`.  The only caveat is that anything in `options` will overwrite anything in the root `data` object.
